### PR TITLE
Use reduced minorVersion to match modern Chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,12 @@ class UserAgent {
 		let fullVersion = require("child_process")
 			.execSync("google-chrome --version");
 
-		this.version = versionRegExp.exec(fullVersion);
-		if (!this.version) {
+		let nonReducedVersion = versionRegExp.exec(fullVersion);
+		if (!nonReducedVersion) {
 			process.exit(1);
 		}
+		let major = /\d+/.exec(nonReducedVersion);
+		this.version = `${major}.0.0.0`;
 		console.log(`Current version: ${this.version}.`);
 	}
 


### PR DESCRIPTION
Context: https://www.chromium.org/updates/ua-reduction/#sample-ua-strings-phase-4
Chrome now sends reduced minorVersion in user-agent string (e.g. `121.0.0.0` instead of `121.0.6167.139`).
I think tdesktop should do the same.